### PR TITLE
Promise states now update properly to reflect their promise chain's value

### DIFF
--- a/src/synchronous.js
+++ b/src/synchronous.js
@@ -5,18 +5,22 @@ var Promise = require('./core.js');
 module.exports = Promise;
 Promise.enableSynchronous = function () {
   Promise.prototype.isPending = function() {
-    return this._state == 0;
+    return this.state() == 0;
   };
 
   Promise.prototype.isFulfilled = function() {
-    return this._state == 1;
+    return this.state() == 1;
   };
 
   Promise.prototype.isRejected = function() {
-    return this._state == 2;
+    return this.state() == 2;
   };
 
   Promise.prototype.value = function () {
+    if (this._state === 3 && this._value instanceof Promise) {
+      return this._value.value();
+    }
+
     if (!this.isFulfilled()) {
       throw new Error('Cannot get a value of an unfulfilled promise.');
     }
@@ -30,6 +34,14 @@ Promise.enableSynchronous = function () {
     }
 
     return this._value;
+  };
+
+  Promise.prototype.state = function () {
+    if (this._state === 3 && this._value instanceof Promise) {
+      return this._value.state();
+    }
+
+    return this._state;
   };
 };
 


### PR DESCRIPTION
A promise that resolves with a promise chain now properly reflects the values for isPending, isFulfilled, isRejected and value. Before it would assume an invalid state of `isPending: false` while being neither fulfilled nor rejected and it's `value()` would point to the promise that it reflects, rather than the value of that promise.