### PR TITLE
Support error-object-less callbacks, like fs.exists

### DIFF
--- a/src/node-extensions.js
+++ b/src/node-extensions.js
@@ -17,8 +17,14 @@ Promise.denodeify = function (fn, argumentCount) {
     var args = Array.prototype.slice.call(arguments, 0,
         argumentCount > 0 ? argumentCount : 0);
     return new Promise(function (resolve, reject) {
-      args.push(function (err, res) {
-        if (err) reject(err);
+      args.push(function () {
+        const [err, res] = arguments;
+        // If only one argument is returned (err) then return that value.
+        // fs.exists('', fileExists => console.log(fileExists));
+        if (arguments.length === 1) {
+          resolve(err);
+        }
+        else if (err) reject(err);
         else resolve(res);
       })
       var res = fn.apply(self, args);


### PR DESCRIPTION
Allows `fs.exists`-like methods that do not return an error object to work with promisify-node.